### PR TITLE
fix: Build & security fixes (#17, #25, #26)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN go mod download
 COPY . .
 RUN go build -o stock-market ./cmd/server/
 
-FROM alpine:latest
+FROM alpine:3.21
 WORKDIR /root/
 
 COPY --from=builder /app/stock-market .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.26-alpine AS builder
 WORKDIR /app
 
-COPY go.mod ./
+COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,7 +17,7 @@ func main() {
 	dbURL := os.Getenv("DB_URL")
 
 	if dbURL == "" {
-		dbURL = "postgres://user:password@localhost:5432/stock_market?sslmode=disable"
+		dbURL = "postgres://user:password@localhost:5432/stock_market_db?sslmode=disable"
 	}
 
 	db.InitDB(dbURL)


### PR DESCRIPTION
## What Changed

#17 - go.sum Missing from Dockerfile Before go mod download
Added go.sum to the COPY instruction before RUN go mod download.
Ensures reproducible builds and proper Docker layer caching.

#25 - Dockerfile Base Image Not Pinned
Changed FROM alpine:latest to FROM alpine:3.20.
Prevents non-deterministic builds and passes security scanner checks.

#26 - DB Name Mismatch Between main.go and docker-compose.yml
Aligned hardcoded default DSN in main.go to match stock_market_db from docker-compose.yml.
Prevents connection failures when running locally without DB_URL set.