### PR TITLE
fix: nginx HA failover, DB connection limits, and README gap (#27, #28, #29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,6 @@ The application will be available at `localhost:<PORT>`.
 - GET /stocks: See the current state of the Bank.
 - POST /wallets/{wallet_id}/stocks/{stock_name}: Buy or sell a single stock.
 - GET /wallets/{wallet_id}: Check all stocks owned by a specific wallet.
+- GET /wallets/{wallet_id}/stocks/{stock_name}: Check the quantity of a specific stock in a wallet.
 - GET /log: View the history of all successful operations (sorted by time).
 - POST /chaos: Simulate a failure by killing the application instance that handles the request.

--- a/internal/db/database.go
+++ b/internal/db/database.go
@@ -3,6 +3,7 @@ package db
 import (
 	"database/sql"
 	"log"
+	"time"
 
 	_ "github.com/lib/pq"
 )
@@ -18,6 +19,10 @@ func InitDB(url string) {
 	if err = DB.Ping(); err != nil {
 		log.Fatalf("cannot connect to DB: %v", err)
 	}
+
+	DB.SetMaxOpenConns(25)
+	DB.SetMaxIdleConns(10)
+	DB.SetConnMaxLifetime(5 * time.Minute)
 
 	queries := []string{
 		`CREATE TABLE IF NOT EXISTS bank_stocks (

--- a/nginx.conf
+++ b/nginx.conf
@@ -13,6 +13,8 @@ http {
 
         location / {
             proxy_pass http://backend_apps;
+            proxy_connect_timeout 1s;
+            proxy_next_upstream error timeout http_502 http_503;
         }
     }
 }


### PR DESCRIPTION
## What Changed

#27 - Nginx Missing proxy_next_upstream — HA Broken During Chaos Window
Added proxy_connect_timeout 1s and proxy_next_upstream error timeout http_502 http_503 to the location block.
Ensures Nginx retries on the live instance instead of returning 502s when chaos kills one upstream.

#28 - Database Connection Pool Left at Unbounded Defaults
Added DB.SetMaxOpenConns(25), DB.SetMaxIdleConns(10), DB.SetConnMaxLifetime(5 * time.Minute) after Ping.
Prevents PostgreSQL max_connections exhaustion under concurrent load.

#29 - README Missing GET /wallets/{wallet_id}/stocks/{stock_name} Endpoint
Added the missing endpoint row to README.md in correct resource hierarchy order.
Keeps documentation in sync with the implemented API surface.